### PR TITLE
feat(layout): 添加 Pad 宽屏单窗口铺满适配

### DIFF
--- a/src/pages.json
+++ b/src/pages.json
@@ -48,7 +48,9 @@
     "navigationBarBackgroundColor": "#000000",
     "navigationBarTextStyle": "@navTxtStyle",
     "navigationBarTitleText": "uView Pro Starter",
-    "navigationStyle": "custom"
+    "navigationStyle": "custom",
+    "rpxCalcMaxDeviceWidth": 1366,
+    "rpxCalcBaseDeviceWidth": 375
   },
   "tabBar": {
     "color": "@tabFontColor",

--- a/src/pages/about/about.vue
+++ b/src/pages/about/about.vue
@@ -663,4 +663,20 @@ function showToast(title: string) {
       text-align: center;
   }
 }
+
+// Pad及宽屏：6列菜单铺满
+@media (min-width: 768px) {
+  .menu-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .about-page {
+    padding: 32rpx;
+    gap: 32rpx;
+  }
+
+  .hero-card__content {
+    padding: 56rpx 48rpx;
+  }
+}
 </style>

--- a/src/pages/home/components-demo.vue
+++ b/src/pages/home/components-demo.vue
@@ -465,4 +465,25 @@ const tabList = [
     border-top: 1rpx solid $u-border-color;
 }
 }
+
+// Pad及宽屏适配：内容铺满
+@media (min-width: 768px) {
+  .app-container {
+    padding: 48rpx;
+  }
+
+  .button-row {
+    flex-wrap: wrap;
+  }
+
+  .feedback-buttons {
+    flex-wrap: wrap;
+  }
+
+  .components-list {
+    .component-item {
+      padding: 24rpx 0;
+    }
+  }
+}
 </style>

--- a/src/pages/home/create-demo.vue
+++ b/src/pages/home/create-demo.vue
@@ -381,4 +381,19 @@ function copyCommand(command: string) {
     }
   }
 }
+
+// Pad及宽屏：铺满适配
+@media (min-width: 768px) {
+  .app-container {
+    padding: 48rpx;
+  }
+
+  .features-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .platforms-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
 </style>

--- a/src/pages/home/home.vue
+++ b/src/pages/home/home.vue
@@ -572,6 +572,43 @@ function goToUrl(url: string) {
   }
 }
 
+// Pad及宽屏：4列卡片铺满
+@media (min-width: 768px) {
+  .project-cards {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .quick-start-actions {
+    flex-direction: row;
+
+    :deep(.u-button) {
+      flex: 1;
+    }
+  }
+
+  .section-card__body {
+    :deep(.u-cell-group) {
+      .u-cell-item {
+        padding: 24rpx 32rpx;
+      }
+    }
+  }
+}
+
+// 超宽屏（iPad Pro横屏等）
+@media (min-width: 1024px) {
+  .hero-section {
+    .hero-content {
+      padding: 80rpx 48rpx;
+    }
+  }
+
+  .app-container {
+    padding: 32rpx;
+    gap: 32rpx;
+  }
+}
+
 // 快速开始内容
 .quick-start-content {
   padding: 24rpx 32rpx 32rpx;

--- a/src/pages/home/http-demo.vue
+++ b/src/pages/home/http-demo.vue
@@ -355,4 +355,15 @@ const configExamples = [
   align-items: center;
   gap: 12rpx;
 }
+
+// Pad及宽屏：铺满适配
+@media (min-width: 768px) {
+  .app-container {
+    padding: 48rpx;
+  }
+
+  .api-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
 </style>

--- a/src/pages/home/pinia-demo.vue
+++ b/src/pages/home/pinia-demo.vue
@@ -361,4 +361,15 @@ const piniaFeatures = [
     gap: 12rpx;
   }
 }
+
+// Pad及宽屏：铺满适配
+@media (min-width: 768px) {
+  .app-container {
+    padding: 48rpx;
+  }
+
+  .examples-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
 </style>

--- a/src/pages/home/uview-intro.vue
+++ b/src/pages/home/uview-intro.vue
@@ -175,4 +175,15 @@ const advantages = computed(() => [
   flex-direction: column;
   gap: 15rpx;
 }
+
+// Pad及宽屏：铺满适配
+@media (min-width: 768px) {
+  .app-container {
+    padding: 48rpx;
+  }
+
+  .features-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
 </style>


### PR DESCRIPTION
- pages.json 添加 rpxCalcMaxDeviceWidth/rpxCalcBaseDeviceWidth 配置
- 所有页面添加 @media (min-width: 768px) 媒体查询
- home.vue 项目卡片 2列→4列，按钮改为横向排列
- about.vue 功能菜单 3列→6列
- 各 demo 页面网格布局增加 Pad 列数

🤖 Generated with [Qoder][https://qoder.com]